### PR TITLE
Remove leftover torch imports

### DIFF
--- a/whisper/__init__.py
+++ b/whisper/__init__.py
@@ -10,7 +10,6 @@ import onnxruntime
 
 from .audio import load_audio, log_mel_spectrogram, pad_or_trim
 from .decoding import DecodingOptions, DecodingResult, decode, detect_language
-from .model import ModelDimensions, Whisper
 from .transcribe import transcribe
 from .version import __version__
 
@@ -105,7 +104,7 @@ def load_model(
     device: str = "cpu",
     download_root: str = None,
     in_memory: bool = False,
-) -> Whisper:
+):
     """
     Load a Whisper ASR model
 
@@ -149,6 +148,8 @@ def load_model(
     ) as fp:
         checkpoint = onnxruntime.sessionInference(fp)
     del checkpoint_file
+
+    from .model import ModelDimensions, Whisper
 
     dims = ModelDimensions(**checkpoint["dims"])
     model = Whisper(dims)

--- a/whisper/__init__.py
+++ b/whisper/__init__.py
@@ -144,17 +144,13 @@ def load_model(
             f"Model {name} not found; available models = {available_models()}"
         )
 
-    with (
-        io.BytesIO(checkpoint_file) if in_memory else open(checkpoint_file, "rb")
-    ) as fp:
-        checkpoint = onnxruntime.sessionInference(fp)
-    del checkpoint_file
+    if in_memory:
+        session = onnxruntime.InferenceSession(checkpoint_file)
+    else:
+        session = onnxruntime.InferenceSession(checkpoint_file)
 
-    dims = ModelDimensions(**checkpoint["dims"])
-    model = Whisper(dims)
-    model.load_state_dict(checkpoint["model_state_dict"])
-
+    model = Whisper(session)
     if alignment_heads is not None:
         model.set_alignment_heads(alignment_heads)
 
-    return model.to(device)
+    return model

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -5,7 +5,6 @@ import warnings
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import numpy as np
-import torch
 import tqdm
 
 from .audio import (
@@ -554,7 +553,6 @@ def cli():
     parser.add_argument("--max_line_width", type=optional_int, default=None, help="(requires --word_timestamps True) the maximum number of characters in a line before breaking the line")
     parser.add_argument("--max_line_count", type=optional_int, default=None, help="(requires --word_timestamps True) the maximum number of lines in a segment")
     parser.add_argument("--max_words_per_line", type=optional_int, default=None, help="(requires --word_timestamps True, no effect with --max_line_width) the maximum number of words in a segment")
-    parser.add_argument("--threads", type=optional_int, default=0, help="number of threads used by torch for CPU inference; supercedes MKL_NUM_THREADS/OMP_NUM_THREADS")
     parser.add_argument("--clip_timestamps", type=str, default="0", help="comma-separated list start,end,start,end,... timestamps (in seconds) of clips to process, where the last end timestamp defaults to the end of the file")
     parser.add_argument("--hallucination_silence_threshold", type=optional_float, help="(requires --word_timestamps True) skip silent periods longer than this threshold (in seconds) when a possible hallucination is detected")
     # fmt: on

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -5,7 +5,6 @@ import warnings
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import numpy as np
-import torch
 import tqdm
 
 from .audio import (
@@ -554,7 +553,12 @@ def cli():
     parser.add_argument("--max_line_width", type=optional_int, default=None, help="(requires --word_timestamps True) the maximum number of characters in a line before breaking the line")
     parser.add_argument("--max_line_count", type=optional_int, default=None, help="(requires --word_timestamps True) the maximum number of lines in a segment")
     parser.add_argument("--max_words_per_line", type=optional_int, default=None, help="(requires --word_timestamps True, no effect with --max_line_width) the maximum number of words in a segment")
-    parser.add_argument("--threads", type=optional_int, default=0, help="number of threads used by torch for CPU inference; supercedes MKL_NUM_THREADS/OMP_NUM_THREADS")
+    parser.add_argument(
+        "--threads",
+        type=optional_int,
+        default=0,
+        help="number of threads used by onnxruntime for CPU inference; supercedes MKL_NUM_THREADS/OMP_NUM_THREADS",
+    )
     parser.add_argument("--clip_timestamps", type=str, default="0", help="comma-separated list start,end,start,end,... timestamps (in seconds) of clips to process, where the last end timestamp defaults to the end of the file")
     parser.add_argument("--hallucination_silence_threshold", type=optional_float, help="(requires --word_timestamps True) skip silent periods longer than this threshold (in seconds) when a possible hallucination is detected")
     # fmt: on


### PR DESCRIPTION
## Summary
- drop torch import from `transcribe.py`
- use scipy-based median filter
- avoid importing model classes when the package is imported

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pip install scipy`
- `pytest -q` *(fails: urllib error when downloading models)*

------
https://chatgpt.com/codex/tasks/task_b_6866b16134ac8328a062ec60e8abb439